### PR TITLE
alternative datapath patch

### DIFF
--- a/graphics/vid.cpp
+++ b/graphics/vid.cpp
@@ -417,11 +417,11 @@ namespace Vid
       width  = cr.Width();
       height = cr.Height();
 
-      S32 l = (CurMode().rect.Width()  - width)  >> 1;
-      S32 t = (CurMode().rect.Height() - height) >> 1;
-			SetWindowPos( hWnd, HWND_TOP, l, t, width, height, NULL);
-
-		  SetRects();
+      S32 l = (GetSystemMetrics(SM_CXSCREEN) - width)  >> 1;
+      S32 t = (GetSystemMetrics(SM_CYSCREEN) - height) >> 1;
+	  
+	  SetWindowPos( hWnd, HWND_TOP, l, t, width, height, NULL);
+	  SetRects();
 
       // finish dx init
 		  if (!InitD3D())

--- a/main/maininit.cpp
+++ b/main/maininit.cpp
@@ -1317,6 +1317,23 @@ struct StaticInit
     // Only absolutely essential (and safe) stuff to be initalized in here
     // Will be called before the C and C++ runtime libraries are inited, and
     // before virtual function tables are setup.
+
+	// check if dr2data process environamet string is set and not empty
+	// if not change current working directory to than path.
+
+	const char * envstr = getenv("dr2data");
+
+	if (envstr)
+	{
+		if (strlen(envstr))
+		{
+			if (!Dir::SetCurrent(envstr))
+			{
+				LOG_WARN(("unable to set current director acording to dr2data environment string"));
+			}
+		}
+	}
+
     Debug::PreIgnition();
     Clock::Time::Init();
     Log::Init();

--- a/sound/sound.cpp
+++ b/sound/sound.cpp
@@ -43,7 +43,9 @@ namespace Sound
       dTracker = new DTrack("Sound", 128);
 
       // Tell MSS where to find its files
-      AIL_set_redist_directory("library\\mss");
+	  char mssdir[PATHNAME_MAX + 1];
+	  Utils::MakePath(mssdir, PATHNAME_MAX, FileSys::GetSub("@rootdir"), "library\\mss", NULL);
+      AIL_set_redist_directory(mssdir);
 
       // Initialize MSS
       AIL_startup();


### PR DESCRIPTION
Enables use of alternatve data path by setting the environment string: dr2data. If this string exist and is not empty the initializationcode simply changes the current working director to this path.  A patch in the sound module was also nessary to make the mss system load from selected path